### PR TITLE
Add support for Linux and MacOS in the MakeFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,25 @@ EXEC = audio_analyzer
 CLIB = -I./libs/portaudio/include ./libs/portaudio/lib/.libs/libportaudio.a \
 -I./libs/fftw-3.3.10/api -lfftw3 -lncurses
 
+PLATFORM := $(shell uname -s)
+
+ifeq ($(PLATFORM), Linux)
+	CXX = $(CXX)
+	ARGS =
+
+else ifeq ($(PLATFORM),Darwin)
+	CXX = clang++
+	ARGS = -framework CoreAudio -framework AudioUnit -framework AudioToolbox \
+                    -framework Carbon
+
+else
+    $(error Unsupported platform: $(PLATFORM))
+endif
+
 $(EXEC): main.cpp
-	g++ -framework CoreAudio -framework AudioUnit -framework AudioToolbox \
--framework Carbon $(CLIB) main.cpp
+	$(CXX) $(ARGS) $(CLIB) -o $@ $^
+
+all: install-deps $(EXEC)
 
 install-deps: install-portaudio install-fftw
 .PHONY: install-deps


### PR DESCRIPTION
**Changes made:**
* Support for the two platforms is done by a `$(shell uname -s)` check. 
* The program currently allows for Linux and Darwin(MacOS) platforms.

**Future improvements:**
* Add support for Windows